### PR TITLE
fix: normalize package names for case-insensitive lookup

### DIFF
--- a/src/req_update_check/core.py
+++ b/src/req_update_check/core.py
@@ -70,7 +70,7 @@ class Requirements:
         res = requests.get(self.pypi_index, headers=self.headers, timeout=10)
         package_index = res.json()["projects"]
         for package in package_index:
-            self.package_index.add(package["name"])
+            self.package_index.add(package["name"].lower())
 
         if self.cache:
             self.cache.set("package-index", list(self.package_index))
@@ -118,18 +118,19 @@ class Requirements:
         return packages
 
     def get_latest_version(self, package_name):
+        normalized_name = package_name.lower()
         if self.allow_cache and self.cache:
-            latest_version = self.cache.get(f"package:{package_name}")
+            latest_version = self.cache.get(f"package:{normalized_name}")
             if latest_version:
                 return latest_version
 
-        res = requests.get(f"{self.pypi_index}{package_name}/", headers=self.headers, timeout=10)
+        res = requests.get(f"{self.pypi_index}{normalized_name}/", headers=self.headers, timeout=10)
         versions = res.json()["versions"]
         # start from the end and find the first version that is not a pre-release
         for version in reversed(versions):
             if not any(x in version for x in ["a", "b", "rc"]):
                 if self.cache:
-                    self.cache.set(f"package:{package_name}", version)
+                    self.cache.set(f"package:{normalized_name}", version)
                 return version
         return None
 
@@ -150,8 +151,8 @@ class Requirements:
             package_name, optional_deps = package_name.split("[")
             logger.info(f"Skipping optional packages '{optional_deps.replace(']', '')}' from {package_name}")
 
-        # check if package is in the index
-        if package_name not in self.package_index:
+        # check if package is in the index (case-insensitive)
+        if package_name.lower() not in self.package_index:
             msg = f"Package {package_name} not found in the index."
             logger.info(msg)
             return
@@ -351,13 +352,14 @@ class Requirements:
 
     def get_package_info(self, package_name: str) -> dict:
         """Get package information using PyPI JSON API."""
+        normalized_name = package_name.lower()
         if self.allow_cache and self.cache:
-            info = self.cache.get(f"package-info:{package_name}")
+            info = self.cache.get(f"package-info:{normalized_name}")
             if info:
                 return info
 
         try:
-            res = requests.get(f"{self.pypi_json_api}{package_name}/json", timeout=10)
+            res = requests.get(f"{self.pypi_json_api}{normalized_name}/json", timeout=10)
             res.raise_for_status()
             data = res.json()
 
@@ -378,7 +380,7 @@ class Requirements:
                     break
 
             if self.cache:
-                self.cache.set(f"package-info:{package_name}", info)
+                self.cache.set(f"package-info:{normalized_name}", info)
         except (requests.RequestException, KeyError, ValueError):
             return {}
         else:

--- a/tests/test_req_cheq.py
+++ b/tests/test_req_cheq.py
@@ -636,5 +636,107 @@ class TestJSONOutput(unittest.TestCase):
         self.assertIn("xml", str(cm.exception))
 
 
+class TestCaseSensitivity(unittest.TestCase):
+    """Tests for case-insensitive package name handling (PEP 503)"""
+
+    def test_get_index_stores_lowercase_names(self):
+        """Test that package names are stored as lowercase in the index"""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "projects": [
+                {"name": "Django"},
+                {"name": "Flask"},
+                {"name": "Requests"},
+            ],
+        }
+
+        with patch("requests.get", return_value=mock_response):
+            req = Requirements("requirements.txt", allow_cache=False)
+            req.get_index()
+
+        # All names should be stored as lowercase
+        self.assertIn("django", req.package_index)
+        self.assertIn("flask", req.package_index)
+        self.assertIn("requests", req.package_index)
+        # Uppercase versions should not be in the index
+        self.assertNotIn("Django", req.package_index)
+        self.assertNotIn("Flask", req.package_index)
+        self.assertNotIn("Requests", req.package_index)
+
+    def test_check_package_finds_lowercase_in_uppercase_index(self):
+        """Test that lowercase package names match uppercase index entries"""
+        req = Requirements("requirements.txt", allow_cache=False)
+        req.package_index = {"django", "flask"}  # lowercase stored
+
+        with patch.object(req, "get_latest_version", return_value="4.2.0"):
+            req.check_package(["django", "4.0.0"])
+
+        # Should find the package and add to updates
+        self.assertEqual(len(req.updates), 1)
+        self.assertEqual(req.updates[0][0], "django")
+
+    def test_check_package_finds_uppercase_in_lowercase_index(self):
+        """Test that uppercase package names match lowercase index entries"""
+        req = Requirements("requirements.txt", allow_cache=False)
+        req.package_index = {"django", "flask"}  # lowercase stored
+
+        with patch.object(req, "get_latest_version", return_value="4.2.0"):
+            req.check_package(["Django", "4.0.0"])
+
+        # Should find the package and add to updates
+        self.assertEqual(len(req.updates), 1)
+        self.assertEqual(req.updates[0][0], "Django")
+
+    def test_check_package_mixed_case_variations(self):
+        """Test that mixed case package names work correctly"""
+        req = Requirements("requirements.txt", allow_cache=False)
+        req.package_index = {"django", "flask", "numpy"}
+
+        test_cases = [
+            ["DJANGO", "4.0.0"],
+            ["DjAnGo", "4.0.0"],
+            ["dJaNgO", "4.0.0"],
+        ]
+
+        with patch.object(req, "get_latest_version", return_value="4.2.0"):
+            for package in test_cases:
+                req.updates = []  # Reset for each test
+                req.check_package(package)
+                self.assertEqual(len(req.updates), 1, f"Failed for case: {package[0]}")
+
+    @patch("requests.get")
+    def test_get_latest_version_uses_lowercase_url(self, mock_get):
+        """Test that get_latest_version uses lowercase in API URL"""
+        mock_response = Mock()
+        mock_response.json.return_value = {"versions": ["4.2.0"]}
+        mock_get.return_value = mock_response
+
+        req = Requirements("requirements.txt", allow_cache=False)
+        req.get_latest_version("Django")
+
+        # Verify the API was called with lowercase package name
+        call_url = mock_get.call_args[0][0]
+        self.assertIn("django", call_url.lower())
+        self.assertNotIn("Django", call_url)
+
+    @patch("requests.get")
+    def test_get_package_info_uses_lowercase_url(self, mock_get):
+        """Test that get_package_info uses lowercase in API URL"""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "info": {"home_page": "https://example.com", "project_urls": {}},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        req = Requirements("requirements.txt", allow_cache=False)
+        req.get_package_info("Django")
+
+        # Verify the API was called with lowercase package name
+        call_url = mock_get.call_args[0][0]
+        self.assertIn("django", call_url.lower())
+        self.assertNotIn("Django", call_url)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fixed case sensitivity issue where lowercase package names (e.g., "django") wouldn't match PyPI's canonical names (e.g., "Django")
- Package names are now normalized to lowercase in the index and during lookups
- API URLs and cache keys also use lowercase for consistency

## Test plan
- [x] Added 6 new tests in `TestCaseSensitivity` class
- [x] All existing tests continue to pass
- [x] Linting passes (`ruff check . && ruff format --check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)